### PR TITLE
Fix handling of conditional queries and responses

### DIFF
--- a/internal/httpclient/cache_test.go
+++ b/internal/httpclient/cache_test.go
@@ -25,11 +25,15 @@ func validateCache(
 ) {
 	t.Helper()
 
-	expectedHashes := make([]string, 0, len(expected))
+	expectedHashesMap := map[string]struct{}{}
 	for _, responses := range expected {
 		for _, resp := range responses {
-			expectedHashes = append(expectedHashes, resp.ContentHash)
+			expectedHashesMap[resp.ContentHash] = struct{}{}
 		}
+	}
+	expectedHashes := make([]string, 0, len(expectedHashesMap))
+	for hash := range expectedHashesMap {
+		expectedHashes = append(expectedHashes, hash)
 	}
 
 	entriesInDB := make(map[string]CachedResponses, len(expected))


### PR DESCRIPTION
If a 304 is returned, but the original query was not conditional, and the cache cannot map it back to a cached query, re-do the query without the conditional information

This is useful in some cases if the server is not responding with an Etag or a Last-Modified entry when returning the 304.