### PR TITLE
Ensure we reached EOF before ingesting the file in the cache

### DIFF
--- a/internal/filecache/filecache.go
+++ b/internal/filecache/filecache.go
@@ -115,6 +115,15 @@ func (f *FileCache) SetupIngestion(
 				return f.cleanup(src, dest, logger)
 			}
 
+			// Was the entire content read? Otherwise fail
+			n, err := src.Read(make([]byte, 1))
+			if err != io.EOF && n != 0 {
+				logger.Error().
+					Err(err).
+					Msg("The file to ingest was not read fully before closing. Skipping ingestion")
+				return f.cleanup(src, dest, logger)
+			}
+
 			hash := hex.EncodeToString(hasher.Sum(nil))
 
 			if err := os.Rename(

--- a/internal/filecache/filecache_test.go
+++ b/internal/filecache/filecache_test.go
@@ -163,6 +163,28 @@ func TestDoesNotIngestFilesThatAreTooBig(t *testing.T) {
 	require.NoError(t, reader.Close())
 }
 
+func TestDoesNotCommitFileThatWasNotReadFully(t *testing.T) {
+	t.Parallel()
+
+	cacheDir := t.TempDir()
+	logger := testutils.TestLogger(t)
+
+	cache, err := filecache.NewFileCache(cacheDir, 100, 10000, logger)
+	require.NoError(t, err)
+
+	reader := cache.SetupIngestion(
+		io.NopCloser(bytes.NewBufferString("hello world!")),
+		func(hash string) { assert.Fail(t, "Hash should not have been called") },
+		func() {},
+		logger,
+	)
+
+	n, err := reader.Read(make([]byte, 5))
+	require.NoError(t, err)
+	assert.Equal(t, 5, n)
+	require.NoError(t, reader.Close())
+}
+
 func TestReturnsErrorOpeningNonExistentFile(t *testing.T) {
 	t.Parallel()
 
@@ -289,6 +311,19 @@ func TestCanGetAllHashes(t *testing.T) {
 	)
 }
 
+func TestCanDelete(t *testing.T) {
+	t.Parallel()
+
+	logger := testutils.TestLogger(t)
+	cache, err := filecache.NewFileCache(t.TempDir(), 100, 1000, logger)
+	require.NoError(t, err)
+
+	hash := ingest(t, cache, "one", logger)
+
+	err = cache.Delete(hash, logger)
+	require.NoError(t, err)
+}
+
 func BenchmarkFileIngestion(b *testing.B) {
 	for _, size := range []string{"10KiB", "100KiB", "1MiB", "10MiB", "100MiB", "1GiB"} {
 		b.Run(size, func(b *testing.B) {
@@ -317,17 +352,4 @@ func BenchmarkFileIngestion(b *testing.B) {
 			}
 		})
 	}
-}
-
-func TestCanDelete(t *testing.T) {
-	t.Parallel()
-
-	logger := testutils.TestLogger(t)
-	cache, err := filecache.NewFileCache(t.TempDir(), 100, 1000, logger)
-	require.NoError(t, err)
-
-	hash := ingest(t, cache, "one", logger)
-
-	err = cache.Delete(hash, logger)
-	require.NoError(t, err)
 }


### PR DESCRIPTION
Previously we were not checking this, which could lead to some incompletely read files to be ingested, which is wrong