### PR TITLE
Validate and verify all log errors raised during tests

### DIFF
--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -15,7 +15,7 @@ import (
 func TestRetrieveNotFound(t *testing.T) {
 	t.Parallel()
 
-	db, err := database.NewDatabase[dbtestutils.TestObj](t.TempDir(), testutils.TestLogger(t))
+	db, err := database.NewDatabase[dbtestutils.TestObj](t.TempDir(), testutils.TestLogger(t, nil))
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, db.Close()) })
 
@@ -27,7 +27,7 @@ func TestRetrieveNotFound(t *testing.T) {
 func TestCanSaveAndRetrieveFromDatabase(t *testing.T) {
 	t.Parallel()
 
-	db, err := database.NewDatabase[dbtestutils.TestObj](t.TempDir(), testutils.TestLogger(t))
+	db, err := database.NewDatabase[dbtestutils.TestObj](t.TempDir(), testutils.TestLogger(t, nil))
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, db.Close()) })
 
@@ -44,7 +44,7 @@ func TestCanSaveAndRetrieveFromDatabase(t *testing.T) {
 func TestRefusesToSaveIfEntryWasUpdated(t *testing.T) {
 	t.Parallel()
 
-	db, err := database.NewDatabase[dbtestutils.TestObj](t.TempDir(), testutils.TestLogger(t))
+	db, err := database.NewDatabase[dbtestutils.TestObj](t.TempDir(), testutils.TestLogger(t, nil))
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, db.Close()) })
 
@@ -73,7 +73,7 @@ func TestRefusesToSaveIfEntryWasUpdated(t *testing.T) {
 func TestCanRetrieveStatistics(t *testing.T) {
 	t.Parallel()
 
-	db, err := database.NewDatabase[dbtestutils.TestObj](t.TempDir(), testutils.TestLogger(t))
+	db, err := database.NewDatabase[dbtestutils.TestObj](t.TempDir(), testutils.TestLogger(t, nil))
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, db.Close()) })
 
@@ -91,7 +91,7 @@ func TestCanRetrieveStatistics(t *testing.T) {
 func TestCanIterateOverEntries(t *testing.T) {
 	t.Parallel()
 
-	db, err := database.NewDatabase[dbtestutils.TestObj](t.TempDir(), testutils.TestLogger(t))
+	db, err := database.NewDatabase[dbtestutils.TestObj](t.TempDir(), testutils.TestLogger(t, nil))
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, db.Close()) })
 
@@ -131,7 +131,7 @@ func TestCanIterateOverEntries(t *testing.T) {
 func TestCanDeleteEntry(t *testing.T) {
 	t.Parallel()
 
-	db, err := database.NewDatabase[dbtestutils.TestObj](t.TempDir(), testutils.TestLogger(t))
+	db, err := database.NewDatabase[dbtestutils.TestObj](t.TempDir(), testutils.TestLogger(t, nil))
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, db.Close()) })
 

--- a/internal/filecache/filecache_test.go
+++ b/internal/filecache/filecache_test.go
@@ -49,7 +49,7 @@ func ingest(
 func TestCanIngestAndRecover(t *testing.T) {
 	t.Parallel()
 
-	logger := testutils.TestLogger(t)
+	logger := testutils.TestLogger(t, nil)
 	cache, err := filecache.NewFileCache(t.TempDir(), 100, 1000, logger)
 	require.NoError(t, err)
 
@@ -85,7 +85,7 @@ func TestCanIngestAndRecover(t *testing.T) {
 
 func TestHandlesConcurrentWrites(t *testing.T) {
 	t.Parallel()
-	logger := testutils.TestLogger(t)
+	logger := testutils.TestLogger(t, nil)
 
 	cache, err := filecache.NewFileCache(t.TempDir(), 100, 1000, logger)
 	require.NoError(t, err)
@@ -124,7 +124,7 @@ func TestHandlesErrorsWhileWriting(t *testing.T) {
 	t.Parallel()
 
 	cacheDir := t.TempDir()
-	logger := testutils.TestLogger(t)
+	logger := testutils.TestLogger(t, []string{"an error happened ingesting the file"})
 
 	cache, err := filecache.NewFileCache(cacheDir, 100, 1000, logger)
 	require.NoError(t, err)
@@ -146,7 +146,7 @@ func TestDoesNotIngestFilesThatAreTooBig(t *testing.T) {
 	t.Parallel()
 
 	cacheDir := t.TempDir()
-	logger := testutils.TestLogger(t)
+	logger := testutils.TestLogger(t, nil)
 
 	cache, err := filecache.NewFileCache(cacheDir, 5, 10, logger)
 	require.NoError(t, err)
@@ -167,7 +167,10 @@ func TestDoesNotCommitFileThatWasNotReadFully(t *testing.T) {
 	t.Parallel()
 
 	cacheDir := t.TempDir()
-	logger := testutils.TestLogger(t)
+	logger := testutils.TestLogger(
+		t,
+		[]string{"The file to ingest was not read fully before closing. Skipping ingestion"},
+	)
 
 	cache, err := filecache.NewFileCache(cacheDir, 100, 10000, logger)
 	require.NoError(t, err)
@@ -188,7 +191,7 @@ func TestDoesNotCommitFileThatWasNotReadFully(t *testing.T) {
 func TestReturnsErrorOpeningNonExistentFile(t *testing.T) {
 	t.Parallel()
 
-	logger := testutils.TestLogger(t)
+	logger := testutils.TestLogger(t, nil)
 	cache, err := filecache.NewFileCache(t.TempDir(), 100, 1000, logger)
 	require.NoError(t, err)
 
@@ -201,7 +204,7 @@ func TestReturnsErrorOpeningNonExistentFile(t *testing.T) {
 func TestCanStatFile(t *testing.T) {
 	t.Parallel()
 
-	logger := testutils.TestLogger(t)
+	logger := testutils.TestLogger(t, nil)
 	cache, err := filecache.NewFileCache(t.TempDir(), 100, 1000, logger)
 	require.NoError(t, err)
 
@@ -226,7 +229,7 @@ func TestCanStatFile(t *testing.T) {
 func TestCanGetStatistics(t *testing.T) {
 	t.Parallel()
 
-	logger := testutils.TestLogger(t)
+	logger := testutils.TestLogger(t, nil)
 	cache, err := filecache.NewFileCache(t.TempDir(), 100, 1000, logger)
 	require.NoError(t, err)
 
@@ -255,7 +258,7 @@ func TestCanGetStatistics(t *testing.T) {
 func TestCanRemoveOldFiles(t *testing.T) {
 	t.Parallel()
 
-	logger := testutils.TestLogger(t)
+	logger := testutils.TestLogger(t, nil)
 	cache, err := filecache.NewFileCache(t.TempDir(), 10, 20, logger)
 	require.NoError(t, err)
 
@@ -279,7 +282,7 @@ func TestCanRemoveOldFiles(t *testing.T) {
 func TestCanGetAllHashes(t *testing.T) {
 	t.Parallel()
 
-	logger := testutils.TestLogger(t)
+	logger := testutils.TestLogger(t, nil)
 	cache, err := filecache.NewFileCache(t.TempDir(), 100, 1000, logger)
 	require.NoError(t, err)
 
@@ -314,7 +317,7 @@ func TestCanGetAllHashes(t *testing.T) {
 func TestCanDelete(t *testing.T) {
 	t.Parallel()
 
-	logger := testutils.TestLogger(t)
+	logger := testutils.TestLogger(t, nil)
 	cache, err := filecache.NewFileCache(t.TempDir(), 100, 1000, logger)
 	require.NoError(t, err)
 
@@ -330,7 +333,7 @@ func BenchmarkFileIngestion(b *testing.B) {
 			sizeB, err := units.DecodeBytes(size)
 			require.NoError(b, err)
 
-			logger := testutils.TestLogger(b)
+			logger := testutils.TestLogger(b, nil)
 			cache, err := filecache.NewFileCache(b.TempDir(), sizeB.Bytes, sizeB.Bytes*10, logger)
 			require.NoError(b, err)
 

--- a/internal/handlers/admin/admin_test.go
+++ b/internal/handlers/admin/admin_test.go
@@ -21,10 +21,13 @@ import (
 	"github.com/benjaminschubert/locaccel/internal/units"
 )
 
-func getAdminServer(t *testing.T) (*httptest.Server, *httpclient.Cache) {
+func getAdminServer(
+	t *testing.T,
+	expectedErrorMessages []string,
+) (*httptest.Server, *httpclient.Cache) {
 	t.Helper()
 
-	logger := testutils.TestLogger(t)
+	logger := testutils.TestLogger(t, expectedErrorMessages)
 
 	handler := &http.ServeMux{}
 
@@ -63,7 +66,7 @@ func getAdminServer(t *testing.T) (*httptest.Server, *httpclient.Cache) {
 func TestProxyLinuxDistributionPackageManagers(t *testing.T) {
 	t.Parallel()
 
-	server, _ := getAdminServer(t)
+	server, _ := getAdminServer(t, nil)
 
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, server.URL, nil)
 	require.NoError(t, err)
@@ -79,7 +82,7 @@ func TestProxyLinuxDistributionPackageManagers(t *testing.T) {
 func TestDeletingUnknownKeysReturnProperError(t *testing.T) {
 	t.Parallel()
 
-	server, _ := getAdminServer(t)
+	server, _ := getAdminServer(t, []string{"Unable to remove entry from cache"})
 
 	req, err := http.NewRequestWithContext(
 		t.Context(),
@@ -98,7 +101,7 @@ func TestDeletingUnknownKeysReturnProperError(t *testing.T) {
 func TestCanDeleteKeyWithNoFileSavedAnymore(t *testing.T) {
 	t.Parallel()
 
-	server, cache := getAdminServer(t)
+	server, cache := getAdminServer(t, nil)
 	require.NoError(t, cache.New([]byte("mykey"), httpclient.CachedResponses{{ContentHash: "123"}}))
 
 	req, err := http.NewRequestWithContext(
@@ -120,13 +123,13 @@ func TestCanDeleteKey(t *testing.T) {
 
 	key := "GET+http://locaccel.test/admin"
 
-	server, cache := getAdminServer(t)
+	server, cache := getAdminServer(t, nil)
 	var hash string
 	f := cache.SetupIngestion(
 		io.NopCloser(bytes.NewReader([]byte("hello world!"))),
 		func(h string) { hash = h },
 		func() {},
-		testutils.TestLogger(t),
+		testutils.TestLogger(t, nil),
 	)
 	_, err := io.ReadAll(f)
 	require.NoError(t, err)
@@ -158,13 +161,13 @@ func TestCanDeleteKey(t *testing.T) {
 func TestCanListEntriesPerHostname(t *testing.T) {
 	t.Parallel()
 
-	server, cache := getAdminServer(t)
+	server, cache := getAdminServer(t, nil)
 	var hash string
 	f := cache.SetupIngestion(
 		io.NopCloser(bytes.NewReader([]byte("hello world!"))),
 		func(h string) { hash = h },
 		func() {},
-		testutils.TestLogger(t),
+		testutils.TestLogger(t, nil),
 	)
 	_, err := io.ReadAll(f)
 	require.NoError(t, err)
@@ -206,7 +209,7 @@ func TestCanListEntriesPerHostname(t *testing.T) {
 func TestRespondsForHealthcheck(t *testing.T) {
 	t.Parallel()
 
-	server, _ := getAdminServer(t)
+	server, _ := getAdminServer(t, nil)
 
 	req, err := http.NewRequestWithContext(
 		t.Context(),

--- a/internal/handlers/galaxy/galaxy_test.go
+++ b/internal/handlers/galaxy/galaxy_test.go
@@ -27,7 +27,7 @@ func TestInstallGalaxyPackages(t *testing.T) {
 		func(t *testing.T, serverURL string) {
 			t.Helper()
 
-			logger := testutils.TestLogger(t)
+			logger := testutils.TestLogger(t, nil)
 			handler := &http.ServeMux{}
 			proxy.RegisterHandler(
 				[]string{"deb.debian.org"},
@@ -64,5 +64,6 @@ func TestInstallGalaxyPackages(t *testing.T) {
 		false,
 		0,
 		1,
+		[]string{"Error forwarding request to upstream"},
 	)
 }

--- a/internal/handlers/goproxy/goproxy_test.go
+++ b/internal/handlers/goproxy/goproxy_test.go
@@ -59,5 +59,6 @@ func TestInstallGoPackages(t *testing.T) {
 		false,
 		0,
 		0,
+		nil,
 	)
 }

--- a/internal/handlers/npm/npm_test.go
+++ b/internal/handlers/npm/npm_test.go
@@ -55,6 +55,7 @@ func TestInstallNpmPackages(t *testing.T) {
 		false,
 		1,
 		-2,
+		nil,
 	)
 }
 

--- a/internal/handlers/oci/oci_test.go
+++ b/internal/handlers/oci/oci_test.go
@@ -86,6 +86,7 @@ func TestDownloadImageWithPodman(t *testing.T) {
 				testcase.needsPrivateCache,
 				0,
 				1,
+				nil,
 			)
 		})
 	}

--- a/internal/handlers/proxy/proxy_test.go
+++ b/internal/handlers/proxy/proxy_test.go
@@ -60,6 +60,7 @@ func TestProxyLinuxDistributionPackageManagers(t *testing.T) {
 				false,
 				0,
 				0,
+				nil,
 			)
 		})
 	}
@@ -68,7 +69,7 @@ func TestProxyLinuxDistributionPackageManagers(t *testing.T) {
 func TestProxyForbidsByDefault(t *testing.T) {
 	t.Parallel()
 
-	logger := testutils.TestLogger(t)
+	logger := testutils.TestLogger(t, nil)
 
 	handler := &http.ServeMux{}
 	proxy.RegisterHandler([]string{}, handler, testutils.NewClient(t, false, logger), nil)

--- a/internal/handlers/pypi/pypi_test.go
+++ b/internal/handlers/pypi/pypi_test.go
@@ -53,6 +53,7 @@ func TestInstallPythonPackages(t *testing.T) {
 		false,
 		0,
 		0,
+		nil,
 	)
 }
 

--- a/internal/handlers/rubygem/rubygem_test.go
+++ b/internal/handlers/rubygem/rubygem_test.go
@@ -46,5 +46,6 @@ func TestInstallRubyGemPackages(t *testing.T) {
 		false,
 		0,
 		0,
+		nil,
 	)
 }

--- a/internal/handlers/testutils/testutils.go
+++ b/internal/handlers/testutils/testutils.go
@@ -64,15 +64,15 @@ func NewClientWithUnderlyingClient(
 	tb.Helper()
 
 	client := &http.Client{
-		Timeout: time.Minute,
+		Timeout: 2 * time.Minute,
 		Transport: &http.Transport{
 			Proxy:                 http.ProxyFromEnvironment,
 			ForceAttemptHTTP2:     true,
 			MaxIdleConns:          20,
 			MaxConnsPerHost:       20,
 			IdleConnTimeout:       90 * time.Second,
-			TLSHandshakeTimeout:   10 * time.Second,
-			ExpectContinueTimeout: 1 * time.Second,
+			TLSHandshakeTimeout:   15 * time.Second,
+			ExpectContinueTimeout: 5 * time.Second,
 		},
 	}
 
@@ -133,6 +133,7 @@ func RunIntegrationTestsForHandler(
 	needsPrivateCache bool,
 	expectedCacheHitsOnInitialQuery uint64,
 	expectedDeltaBetweenCacheHitsOnCachedQueryAndcacheMisses int64,
+	expectedErrorMessagesWhenOffline []string,
 ) {
 	t.Helper()
 
@@ -144,7 +145,7 @@ func RunIntegrationTestsForHandler(
 		t.Run(fmt.Sprintf("upstreamCache=%v", useUpstreamCache), func(t *testing.T) {
 			t.Parallel()
 
-			logger := TestLogger(t)
+			logger := TestLogger(t, nil)
 			var upstreams []*url.URL
 			counterMiddleware := NewRequestCounterMiddleware(t)
 
@@ -190,7 +191,7 @@ func RunIntegrationTestsForHandler(
 	t.Run("UpstreamDown", func(t *testing.T) {
 		t.Parallel()
 
-		logger := TestLogger(t)
+		logger := TestLogger(t, expectedErrorMessagesWhenOffline)
 		handler := &http.ServeMux{}
 		counterMiddleware := NewRequestCounterMiddleware(t)
 		cachingClient, httpClient := NewClientWithUnderlyingClient(

--- a/internal/handlers/utils_test.go
+++ b/internal/handlers/utils_test.go
@@ -63,7 +63,7 @@ func TestCanForwardBasicQuery(t *testing.T) {
 			t,
 			false,
 			func(r *http.Request, s string) {},
-			testutils.TestLogger(t),
+			testutils.TestLogger(t, nil),
 		),
 		nil,
 		nil,
@@ -94,7 +94,7 @@ func TestReturnsNotModifiedIfMatchesOriginalQuery(t *testing.T) {
 			t,
 			false,
 			func(r *http.Request, s string) {},
-			testutils.TestLogger(t),
+			testutils.TestLogger(t, nil),
 		),
 		func(body []byte, resp *http.Response, jsonHandler *handlers.JSONHandler) error {
 			_, err := jsonHandler.Buffer.WriteString("Hi!")
@@ -130,7 +130,7 @@ func TestReturnsBadGatewayWhenUnableToContactUpstream(t *testing.T) {
 			t,
 			false,
 			func(r *http.Request, s string) {},
-			testutils.TestLogger(t),
+			testutils.TestLogger(t, nil),
 		),
 		nil,
 		nil,
@@ -159,7 +159,7 @@ func TestReturnsErrorOnTimeoutFromUpstream(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	httpClient, underlyingClient := testutils.NewClientWithUnderlyingClient(
-		t, false, func(r *http.Request, s string) {}, testutils.TestLogger(t),
+		t, false, func(r *http.Request, s string) {}, testutils.TestLogger(t, nil),
 	)
 	underlyingClient.Timeout = 5 * time.Millisecond
 
@@ -197,7 +197,7 @@ func TestCanModifyQueryBody(t *testing.T) {
 			t,
 			false,
 			func(r *http.Request, s string) {},
-			testutils.TestLogger(t),
+			testutils.TestLogger(t, nil),
 		),
 		func(body []byte, resp *http.Response, jsonHandler *handlers.JSONHandler) error {
 			_, err := jsonHandler.Buffer.WriteString("Hi!")
@@ -230,7 +230,7 @@ func TestReturnProperErrorWhenUnableToModify(t *testing.T) {
 			t,
 			false,
 			func(r *http.Request, s string) {},
-			testutils.TestLogger(t),
+			testutils.TestLogger(t, nil),
 		),
 		func(body []byte, resp *http.Response, jsonHandler *handlers.JSONHandler) error {
 			return errTest
@@ -261,7 +261,7 @@ func TestCanRecoverFromUpstreamError(t *testing.T) {
 			t,
 			false,
 			func(r *http.Request, s string) {},
-			testutils.TestLogger(t),
+			testutils.TestLogger(t, nil),
 		),
 		nil,
 		func(w http.ResponseWriter, err error) error {
@@ -294,7 +294,7 @@ func TestReportsErrorsFromAFailedRecovery(t *testing.T) {
 			t,
 			false,
 			func(r *http.Request, s string) {},
-			testutils.TestLogger(t),
+			testutils.TestLogger(t, nil),
 		),
 		nil,
 		func(w http.ResponseWriter, err error) error {
@@ -341,7 +341,7 @@ func TestHandledModifyingGzippedRequestsTransparently(t *testing.T) {
 			t,
 			false,
 			func(r *http.Request, s string) {},
-			testutils.TestLogger(t),
+			testutils.TestLogger(t, nil),
 		),
 		func(body []byte, resp *http.Response, jsonHandler *handlers.JSONHandler) error {
 			assert.Equal(t, "Hello!", string(body))
@@ -394,7 +394,7 @@ func BenchmarkHandlingOfGzipResponses(b *testing.B) {
 				b,
 				false,
 				func(r *http.Request, s string) {},
-				testutils.TestLogger(b),
+				testutils.TestLogger(b, nil),
 			)
 
 			for b.Loop() {

--- a/internal/httpclient/cache_test.go
+++ b/internal/httpclient/cache_test.go
@@ -100,7 +100,7 @@ func TestCanGetStatisticsOnEmptyCache(t *testing.T) {
 		t.TempDir(),
 		units.Bytes{Bytes: 10},
 		units.Bytes{Bytes: 20},
-		testutils.TestLogger(t),
+		testutils.TestLogger(t, nil),
 	)
 	require.NoError(t, err)
 	defer func() { require.NoError(t, cache.Close()) }()
@@ -122,7 +122,7 @@ func TestCanGetStatistics(t *testing.T) {
 		t.TempDir(),
 		units.Bytes{Bytes: 10},
 		units.Bytes{Bytes: 20},
-		testutils.TestLogger(t),
+		testutils.TestLogger(t, nil),
 	)
 	require.NoError(t, err)
 	defer func() { require.NoError(t, cache.Close()) }()
@@ -171,7 +171,7 @@ func TestDoesNotCleanOldEntriesWithCacheUnderLimit(t *testing.T) {
 		t.TempDir(),
 		units.Bytes{Bytes: 10},
 		units.Bytes{Bytes: 20},
-		testutils.TestLogger(t),
+		testutils.TestLogger(t, nil),
 	)
 	require.NoError(t, err)
 	defer func() { require.NoError(t, cache.Close()) }()
@@ -205,7 +205,7 @@ func TestCanCleanOldEntries(t *testing.T) {
 		cachePath,
 		units.Bytes{Bytes: 10},
 		units.Bytes{Bytes: 20},
-		testutils.TestLogger(t),
+		testutils.TestLogger(t, nil),
 	)
 	require.NoError(t, err)
 	defer func() { require.NoError(t, cache.Close()) }()

--- a/internal/httpclient/client_test.go
+++ b/internal/httpclient/client_test.go
@@ -42,7 +42,7 @@ func setup(
 	t.Helper()
 
 	cachePath := t.TempDir()
-	logger := testutils.TestLogger(t)
+	logger := testutils.TestLogger(t, nil)
 	testTime, err := time.Parse(time.RFC3339, "2024-01-01T12:13:14Z")
 	require.NoError(t, err)
 	clock = &Clock{testTime}
@@ -80,7 +80,7 @@ func makeRequest(
 
 	req, err := http.NewRequestWithContext(t.Context(), method, uri, nil)
 	require.NoError(t, err)
-	logger := testutils.TestLogger(t)
+	logger := testutils.TestLogger(t, nil)
 	req = req.WithContext(logger.WithContext(req.Context()))
 
 	req.Header = headers
@@ -1050,7 +1050,7 @@ func TestClientAddsConditionalQueriesInformation(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			t.Parallel()
 
-			logger := testutils.TestLogger(t)
+			logger := testutils.TestLogger(t, nil)
 			cache, err := NewCache(
 				t.TempDir(),
 				units.Bytes{Bytes: 100},

--- a/internal/httpclient/internal/httpcaching/cachecontrol_test.go
+++ b/internal/httpclient/internal/httpcaching/cachecontrol_test.go
@@ -40,7 +40,7 @@ func TestCanParseValidHeaders(t *testing.T) {
 
 			result, err := httpcaching.ParseCacheControlDirective(
 				[]string{tc.header},
-				testutils.TestLogger(t),
+				testutils.TestLogger(t, nil),
 			)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expected, result)
@@ -63,7 +63,7 @@ func TestIgnoresDuplicateHeaderValues(t *testing.T) {
 
 			result, err := httpcaching.ParseCacheControlDirective(
 				tc.header,
-				testutils.TestLogger(t),
+				testutils.TestLogger(t, nil),
 			)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expected, result)
@@ -85,7 +85,7 @@ func TestErrorsOnInvalidHeaders(t *testing.T) {
 
 			_, err := httpcaching.ParseCacheControlDirective(
 				[]string{header},
-				testutils.TestLogger(t),
+				testutils.TestLogger(t, nil),
 			)
 			require.ErrorIs(t, err, httpcaching.ErrInvalidArgument)
 		})
@@ -104,7 +104,7 @@ func TestIgnoreInvalidDirective(t *testing.T) {
 
 			result, err := httpcaching.ParseCacheControlDirective(
 				[]string{header},
-				testutils.TestLogger(t),
+				testutils.TestLogger(t, nil),
 			)
 			require.NoError(t, err)
 			assert.Equal(t, httpcaching.CacheControlResponseDirective{}, result)
@@ -117,7 +117,7 @@ func TestCanComposeMultipleHeaders(t *testing.T) {
 
 	result, err := httpcaching.ParseCacheControlDirective(
 		[]string{"max-age=123", "must-revalidate, no-cache"},
-		testutils.TestLogger(t),
+		testutils.TestLogger(t, nil),
 	)
 	require.NoError(t, err)
 	assert.Equal(

--- a/internal/httpclient/internal/httpcaching/caching_test.go
+++ b/internal/httpclient/internal/httpcaching/caching_test.go
@@ -45,7 +45,7 @@ func TestResponseIsCacheable(t *testing.T) {
 				isCacheable, explicit := httpcaching.IsCacheable(
 					&resp,
 					private,
-					testutils.TestLogger(t),
+					testutils.TestLogger(t, nil),
 				)
 				assert.Equal(t, tc.expected, isCacheable)
 				assert.Equal(t, tc.explicit, explicit)

--- a/internal/httpclient/internal/httpcaching/freshness_test.go
+++ b/internal/httpclient/internal/httpcaching/freshness_test.go
@@ -15,9 +15,10 @@ func TestGetFreshness(t *testing.T) {
 	t.Parallel()
 
 	for _, tc := range []struct {
-		description string
-		headers     http.Header
-		expected    int
+		description           string
+		headers               http.Header
+		expected              int
+		expectedErrorMEssages []string
 	}{
 		{
 			"s-max-age-precedence",
@@ -26,6 +27,7 @@ func TestGetFreshness(t *testing.T) {
 				"Expires":       []string{"Sun, 01 Jan 2012 12:00:00 GMT"},
 			},
 			1,
+			nil,
 		},
 		{
 			"max-age-over-expires",
@@ -34,6 +36,7 @@ func TestGetFreshness(t *testing.T) {
 				"Expires":       []string{"Sun, 01 Jan 2012 12:00:00 GMT"},
 			},
 			2,
+			nil,
 		},
 		{
 			"expires",
@@ -42,6 +45,7 @@ func TestGetFreshness(t *testing.T) {
 				"Expires": []string{"Sun, 01 Jan 2012 12:00:00 GMT"},
 			},
 			3600,
+			nil,
 		},
 		{
 			"default-if-invalid-expires",
@@ -49,6 +53,7 @@ func TestGetFreshness(t *testing.T) {
 				"Expires": []string{"hi"},
 			},
 			0,
+			nil,
 		},
 		{
 			"default-if-invalid-date",
@@ -57,6 +62,7 @@ func TestGetFreshness(t *testing.T) {
 				"Date":    []string{"hi"},
 			},
 			0,
+			[]string{"BUG: Date header is in an invalid format, which should not happen"},
 		},
 		{
 			"last-modified",
@@ -65,6 +71,7 @@ func TestGetFreshness(t *testing.T) {
 				"Date":          []string{"Sun, 01 Jan 2012 10:00:00 GMT"},
 			},
 			3600,
+			nil,
 		},
 		{
 			"default-if-invalid-last-modified",
@@ -72,6 +79,7 @@ func TestGetFreshness(t *testing.T) {
 				"Last-Modified": []string{"hi"},
 			},
 			0,
+			nil,
 		},
 		{
 			"default-if-invalid-date-on-last-modified",
@@ -80,17 +88,24 @@ func TestGetFreshness(t *testing.T) {
 				"Date":          []string{"hi"},
 			},
 			0,
+			[]string{"BUG: Date header is in an invalid format, which should not happen"},
 		},
 	} {
 		t.Run(tc.description, func(t *testing.T) {
 			t.Parallel()
 
+			logger := testutils.TestLogger(t, tc.expectedErrorMEssages)
+
 			cacheControl, err := ParseCacheControlDirective(
 				tc.headers["Cache-Control"],
-				testutils.TestLogger(t),
+				logger,
 			)
 			require.NoError(t, err)
-			freshness := getFreshnessLifetime(tc.headers, cacheControl, testutils.TestLogger(t))
+			freshness := getFreshnessLifetime(
+				tc.headers,
+				cacheControl,
+				logger,
+			)
 			require.Equal(t, time.Second*time.Duration(tc.expected), freshness)
 		})
 	}
@@ -106,7 +121,7 @@ func TestGetCurrentAge(t *testing.T) {
 		},
 		time.Now().Add(-time.Second*40),
 		time.Now().Add(-time.Second*30),
-		testutils.TestLogger(t),
+		testutils.TestLogger(t, nil),
 		time.Now,
 	)
 	require.Equal(
@@ -129,7 +144,7 @@ func TestGetCurrentAgeHandlesInvalidAgeValues(t *testing.T) {
 		},
 		time.Now().Add(-time.Second*40),
 		time.Now().Add(-time.Second*30),
-		testutils.TestLogger(t),
+		testutils.TestLogger(t, []string{"response has an invalid Age header"}),
 		time.Now,
 	)
 
@@ -150,7 +165,10 @@ func TestGetCurrentAgeAssumeInvalidDateIsNowHeader(t *testing.T) {
 		},
 		time.Now().Add(-time.Second*40),
 		time.Now().Add(-time.Second*30),
-		testutils.TestLogger(t),
+		testutils.TestLogger(
+			t,
+			[]string{"BUG: Date header is in an invalid format, which should not happen"},
+		),
 		time.Now,
 	)
 
@@ -173,7 +191,7 @@ func TestIsFresh(t *testing.T) {
 		},
 		CacheControlResponseDirective{SMaxAge: 300 * time.Second},
 		time.Now().Add(-time.Second*120),
-		testutils.TestLogger(t),
+		testutils.TestLogger(t, nil),
 		time.Since,
 	)
 	assert.Equal(t, time.Second*120, age)
@@ -192,7 +210,7 @@ func TestIsNotFresh(t *testing.T) {
 		},
 		CacheControlResponseDirective{SMaxAge: 30 * time.Second},
 		time.Now().Add(-time.Second*120),
-		testutils.TestLogger(t),
+		testutils.TestLogger(t, nil),
 		time.Since,
 	)
 	assert.Equal(t, time.Second*120, age)

--- a/internal/httpclient/internal/httpcaching/vary_test.go
+++ b/internal/httpclient/internal/httpcaching/vary_test.go
@@ -60,7 +60,7 @@ func TestMatchVaryHeaders(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			t.Parallel()
 
-			match := MatchVaryHeaders(tc.reqHeaders, tc.varyHeaders, testutils.TestLogger(t))
+			match := MatchVaryHeaders(tc.reqHeaders, tc.varyHeaders, testutils.TestLogger(t, nil))
 			require.Equal(t, tc.expected, match)
 		})
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -13,7 +13,7 @@ import (
 func TestServerInitialization(t *testing.T) {
 	t.Parallel()
 
-	logger := testutils.TestLogger(t)
+	logger := testutils.TestLogger(t, nil)
 
 	conf, err := config.Default(func(s string) (string, bool) { return "", false })
 	require.NoError(t, err)

--- a/internal/testutils/testutils.go
+++ b/internal/testutils/testutils.go
@@ -9,10 +9,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestLogger(tb testing.TB) *zerolog.Logger {
+type LogRecordHook struct {
+	ErrorMessages []string
+}
+
+func (l *LogRecordHook) Run(e *zerolog.Event, level zerolog.Level, msg string) {
+	if level >= zerolog.ErrorLevel {
+		l.ErrorMessages = append(l.ErrorMessages, msg)
+	}
+}
+
+func TestLogger(tb testing.TB, expectedErrors []string) *zerolog.Logger {
 	tb.Helper()
 
-	logger := zerolog.New(zerolog.NewConsoleWriter(zerolog.ConsoleTestWriter(tb)))
+	logRecorder := LogRecordHook{}
+	tb.Cleanup(func() {
+		require.Equal(tb, expectedErrors, logRecorder.ErrorMessages)
+	})
+
+	logger := zerolog.New(zerolog.NewConsoleWriter(zerolog.ConsoleTestWriter(tb))).
+		Hook(&logRecorder)
 	return &logger
 }
 


### PR DESCRIPTION
This would have caught a few bugs we have seen recently. Let's ensure we validate everything error and above at the end of each test run